### PR TITLE
Security update

### DIFF
--- a/open_in_mpv/open_in_mpv.py
+++ b/open_in_mpv/open_in_mpv.py
@@ -193,6 +193,10 @@ def real_main(log: TextIO) -> int:
         logger.exception('No URL was given')
         print(json.dumps(dict(message='Missing URL!')))
         return 1
+    if 'https' not in url:
+        logger.exception('The url appears to not have a secure connection.')
+        print(json.dumps(dict(message='Security Exception!')))
+        return 1
     if (is_debug := message.get('debug', False)):
         logger.info('Debug mode enabled.')
     single: bool = message.get('single', True)


### PR DESCRIPTION
Only allow a url with 'https', Perhaps at some point allow this to be configurable to the user; but by default open-in-mpv should only allow secure connections.